### PR TITLE
Update the find_by to full_name which allows matching on folder names

### DIFF
--- a/read_files.go
+++ b/read_files.go
@@ -163,7 +163,7 @@ func read_files() ( map[string]DocInfo ) {
             f.full_name     = full_name
             f.size          = int64( size )
             f.pages         = int64( pages )
-            f.find_by       = strings.ToLower( name )
+            f.find_by       = strings.ToLower( full_name )
 
             rv[f.id] = f
 


### PR DESCRIPTION
This, in my quick test, allowed me to use the name of a folder on  the Remarkable to download all the files in folder.

I'll admit I did this on another machine and this is a re-implementation I'll give a better test as I go.

From memory it pulled the full folder structure but I'll re-test this